### PR TITLE
fix support when ctags record don't have an end of line mark ("$/")

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -107,8 +107,8 @@ const toTargetAddress = s => {
     try {
         switch(s[0]) {
         case '/':
-            matches = s.match(/^\/\^(.+)\$\/\s*;?/)
-            return matches ? matches[1] : s
+            matches = s.match(/^\/(\^)?(?<exp>.+(?<!\$))(\$)?\/\s*;?/)
+            return matches ? matches.groups.exp : s
         case '?':
             matches = s.match(/^\?(.+)\?\s*;?/)
             return matches ? matches[1] : s


### PR DESCRIPTION
When CTags see a big line contains a definision, sometimes the line is cut in the middle. In these cases, CTags doesn't ends with the "$" sign before the last "/" character.

This commit fixes the bug of this extension, that didn't support this case before.

Specifically, before this commit, VSCode opens the file but doesn't navigate to the right line.